### PR TITLE
fix(ci): add explicit permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Full matrix on PR — weekly cadence (Dependabot 14d), so cost is acceptable
 # Mirrors release.yml build steps but without packaging/release
 
@@ -14,6 +17,8 @@ jobs:
   check:
     name: Check (just check)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -40,6 +45,8 @@ jobs:
   build:
     name: Build (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,15 @@ on:
 env:
   BINARY_NAME: artefact-cli
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
@@ -87,6 +92,8 @@ jobs:
     name: Build (${{ matrix.platform }})
     needs: prepare
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
- ci.yml: add top-level and job-level permissions: contents: read
  for check and build (fixes CodeQL alerts #3, #4 on main)
- release.yml: add top-level contents: read and job-level
  permissions for prepare and build (fixes alerts #1, #2),
  keeps release job contents: write
- satisfies CodeQL 'Workflow does not contain permissions'
  (medium) for stacked PR fix-ci-security

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>