### PR TITLE
fix(clippy): resolve all just check warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,9 +737,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
 dependencies = [
  "bytemuck",
 ]
@@ -963,9 +963,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rand_core = { version = "0.9.3" }
 rayon = { version = "1.11.0" }
 thiserror = { version = "2.0.17" }
 wasm-bindgen = { version = "0.2.104" }
-wide = { version = "0.7.33" }
+wide = { version = "1.6.1" }
 zune-core = { version = "0.5.0-rc2" }
 zune-jpeg = { path = "backend/zune-jpeg" }
 zune-ppm = { version = "0.5.0-rc0" }

--- a/backend/artefact-core/benches/boxing.rs
+++ b/backend/artefact-core/benches/boxing.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use criterion::Criterion;
-use rand::Rng;
+use rand::RngExt;
 use wide::f32x8;
 
 fn boxing(
@@ -51,7 +51,7 @@ fn boxing_simd(
             for in_y in 0..8 {
                 let row_start = ((block_y * 8 + in_y) * rounded_px_w + (block_x * 8)) as usize;
                 let result = f32x8::from(&input[row_start..row_start + 8]);
-                output[index..index + 8].copy_from_slice(result.as_array_ref());
+                output[index..index + 8].copy_from_slice(result.as_array());
                 index += 8;
             }
         }
@@ -131,7 +131,7 @@ pub fn unboxing_simd(
                 let result = f32x8::from(&input[index..index + 8]);
 
                 let row_start = ((block_y * 8 + in_y) * rounded_px_w + (block_x * 8)) as usize;
-                output[row_start..row_start + 8].copy_from_slice(result.as_array_ref());
+                output[row_start..row_start + 8].copy_from_slice(result.as_array());
                 index += 8;
             }
         }

--- a/backend/artefact-core/benches/casting.rs
+++ b/backend/artefact-core/benches/casting.rs
@@ -1,12 +1,13 @@
 use std::hint::black_box;
 
 use criterion::Criterion;
-use rand::Rng;
+use rand::RngExt;
 
 fn safe_cast(input: Vec<u16>) -> Vec<f32> {
     input.into_iter().map(|x| x as f32).collect()
 }
 
+#[allow(clippy::uninit_vec)]
 fn unsafe_cast(input: Vec<u16>) -> Vec<f32> {
     let mut output = Vec::with_capacity(input.len());
     unsafe {

--- a/backend/artefact-core/benches/dct.rs
+++ b/backend/artefact-core/benches/dct.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::excessive_precision)]
 
 use criterion::Criterion;
-use rand::Rng;
+use rand::RngExt;
 use wide::f32x8;
 
 pub const C8_1R: f32 = 0.490_392_640_201_615_224_56;
@@ -14,7 +14,7 @@ pub const C8_2I: f32 = 0.191_341_716_182_544_885_86;
 pub const C8_3R: f32 = 0.415_734_806_151_272_618_54;
 pub const C8_3I: f32 = 0.277_785_116_509_801_112_37;
 pub const C8_4R: f32 = 0.353_553_390_593_273_762_20;
-pub const W8_4R: f32 = 0.707_106_781_186_547_524_40;
+pub const W8_4R: f32 = std::f32::consts::FRAC_1_SQRT_2;
 
 pub fn idct8x8s_simd(a: &mut [f32; 64]) {
     {
@@ -47,14 +47,14 @@ pub fn idct8x8s_simd(a: &mut [f32; 64]) {
         x2i = x0i - xi;
         x0r += xr;
         x0i += xi;
-        a[0 * 8..0 * 8 + 8].copy_from_slice((x0r + x1r).as_array_ref());
-        a[7 * 8..7 * 8 + 8].copy_from_slice((x0r - x1r).as_array_ref());
-        a[2 * 8..2 * 8 + 8].copy_from_slice((x0i + x1i).as_array_ref());
-        a[5 * 8..5 * 8 + 8].copy_from_slice((x0i - x1i).as_array_ref());
-        a[4 * 8..4 * 8 + 8].copy_from_slice((x2r - x3i).as_array_ref());
-        a[3 * 8..3 * 8 + 8].copy_from_slice((x2r + x3i).as_array_ref());
-        a[6 * 8..6 * 8 + 8].copy_from_slice((x2i - x3r).as_array_ref());
-        a[1 * 8..1 * 8 + 8].copy_from_slice((x2i + x3r).as_array_ref());
+        a[0 * 8..0 * 8 + 8].copy_from_slice((x0r + x1r).as_array());
+        a[7 * 8..7 * 8 + 8].copy_from_slice((x0r - x1r).as_array());
+        a[2 * 8..2 * 8 + 8].copy_from_slice((x0i + x1i).as_array());
+        a[5 * 8..5 * 8 + 8].copy_from_slice((x0i - x1i).as_array());
+        a[4 * 8..4 * 8 + 8].copy_from_slice((x2r - x3i).as_array());
+        a[3 * 8..3 * 8 + 8].copy_from_slice((x2r + x3i).as_array());
+        a[6 * 8..6 * 8 + 8].copy_from_slice((x2i - x3r).as_array());
+        a[1 * 8..1 * 8 + 8].copy_from_slice((x2i + x3r).as_array());
     }
 
     {
@@ -177,7 +177,7 @@ pub fn dct_benches(c: &mut Criterion) {
     let mut arr_a = [0.0; 64];
     arr_a.iter_mut().for_each(|x| *x = rng.random());
 
-    let mut arr_b = arr_a.clone();
+    let mut arr_b = arr_a;
 
     group.bench_function("idct8x8s", |b| b.iter(|| idct8x8s(&mut arr_a)));
 

--- a/backend/artefact-core/benches/init_slice.rs
+++ b/backend/artefact-core/benches/init_slice.rs
@@ -1,5 +1,5 @@
 use criterion::Criterion;
-use rand::Rng;
+use rand::RngExt;
 use wide::f32x8;
 
 fn init_with_copy(target: [f32; 64]) -> f32x8 {
@@ -20,8 +20,8 @@ pub fn init_slice_benches(c: &mut Criterion) {
     let mut target = [0.0; 64];
     let mut rng = rand::rng();
 
-    for i in 0..64 {
-        target[i] = rng.random();
+    for target_item in &mut target {
+        *target_item = rng.random();
     }
 
     let mut group = c.benchmark_group("init_slice");

--- a/backend/artefact-core/pipeline_scalar/compute_step.rs
+++ b/backend/artefact-core/pipeline_scalar/compute_step.rs
@@ -60,7 +60,7 @@ pub fn compute_step(
         // Only update if gradient norm is non-zero
         if norm != 0.0 {
             for i in 0..max_rounded_px_count {
-                aux.fdata[i] -= step_size * (aux.obj_gradient[i] / norm);
+                aux.fdata[i] = step_size.mul_add(-(aux.obj_gradient[i] / norm), aux.fdata[i]);
             }
         }
     }

--- a/backend/artefact-core/pipeline_scalar/compute_step_prob.rs
+++ b/backend/artefact-core/pipeline_scalar/compute_step_prob.rs
@@ -23,7 +23,7 @@ pub fn compute_step_prob(
             // Process each coefficient in current block
             for (j, cosb) in cosbs.iter_mut().enumerate() {
                 // Calculate difference from original DCT coefficients
-                *cosb -= coef.dct_coefs[i * 64 + j] * coef.quant_table[j];
+                *cosb = coef.dct_coefs[i * 64 + j].mul_add(-coef.quant_table[j], *cosb);
 
                 // Calculate derivative for gradient
                 *cosb /= (coef.quant_table[j]).powi(2);
@@ -50,7 +50,10 @@ pub fn compute_step_prob(
                             debug_assert!(x < max_rounded_px_w);
 
                             // Update gradient with scaled cosine value
-                            obj_gradient[(y * max_rounded_px_w + x) as usize] += alpha * cosbs[j];
+                            obj_gradient[(y * max_rounded_px_w + x) as usize] = alpha.mul_add(
+                                cosbs[j],
+                                obj_gradient[(y * max_rounded_px_w + x) as usize],
+                            );
                         }
                     }
                 }

--- a/backend/artefact-core/pipeline_scalar/compute_step_tv.rs
+++ b/backend/artefact-core/pipeline_scalar/compute_step_tv.rs
@@ -68,19 +68,24 @@ pub fn compute_step_tv_inner(
     g_norm = g_norm.sqrt();
 
     let alpha = 1.0 / (nchannel as f32).sqrt();
-    *tv += f64::from(alpha) * f64::from(g_norm);
+    *tv = f64::mul_add(f64::from(alpha), f64::from(g_norm), *tv);
 
     // compute derivatives
     if g_norm != 0.0 {
         for c in 0..nchannel {
-            auxs[c].obj_gradient[curr_px_idx] += alpha * -(g_xs[c] + g_ys[c]) / g_norm;
+            auxs[c].obj_gradient[curr_px_idx] = alpha.mul_add(
+                -(g_xs[c] + g_ys[c]) / g_norm,
+                auxs[c].obj_gradient[curr_px_idx],
+            );
 
             if !px_at_right_edge {
-                auxs[c].obj_gradient[next_px_idx] += alpha * g_xs[c] / g_norm;
+                auxs[c].obj_gradient[next_px_idx] =
+                    alpha.mul_add(g_xs[c] / g_norm, auxs[c].obj_gradient[next_px_idx]);
             }
 
             if !px_at_bottom_edge {
-                auxs[c].obj_gradient[below_px_idx] += alpha * g_ys[c] / g_norm;
+                auxs[c].obj_gradient[below_px_idx] =
+                    alpha.mul_add(g_ys[c] / g_norm, auxs[c].obj_gradient[below_px_idx]);
             }
         }
     }

--- a/backend/artefact-core/pipeline_scalar/compute_step_tv2.rs
+++ b/backend/artefact-core/pipeline_scalar/compute_step_tv2.rs
@@ -100,37 +100,53 @@ fn compute_step_tv2_inner(
         let g_xy_sym = g_xy_syms[c];
         let aux = &mut auxs[c];
 
-        aux.obj_gradient[(curr_y * max_rounded_px_w + curr_x) as usize] +=
-            alpha * (-(mul_add!(2.0_f32, g_yy, mul_add!(2.0_f32, g_xx, 2.0 * g_xy_sym))) / g2_norm);
+        aux.obj_gradient[(curr_y * max_rounded_px_w + curr_x) as usize] = alpha.mul_add(
+            -(mul_add!(2.0_f32, g_yy, mul_add!(2.0_f32, g_xx, 2.0 * g_xy_sym))) / g2_norm,
+            aux.obj_gradient[(curr_y * max_rounded_px_w + curr_x) as usize],
+        );
 
         if curr_x > 0 {
-            aux.obj_gradient[(curr_y * max_rounded_px_w + (curr_x - 1)) as usize] +=
-                alpha * ((g_xy_sym + g_xx) / g2_norm);
+            aux.obj_gradient[(curr_y * max_rounded_px_w + (curr_x - 1)) as usize] = alpha.mul_add(
+                (g_xy_sym + g_xx) / g2_norm,
+                aux.obj_gradient[(curr_y * max_rounded_px_w + (curr_x - 1)) as usize],
+            );
         }
 
         if curr_x < max_rounded_px_w - 1 {
-            aux.obj_gradient[(curr_y * max_rounded_px_w + (curr_x + 1)) as usize] +=
-                alpha * ((g_xy_sym + g_xx) / g2_norm);
+            aux.obj_gradient[(curr_y * max_rounded_px_w + (curr_x + 1)) as usize] = alpha.mul_add(
+                (g_xy_sym + g_xx) / g2_norm,
+                aux.obj_gradient[(curr_y * max_rounded_px_w + (curr_x + 1)) as usize],
+            );
         }
 
         if curr_y > 0 {
-            aux.obj_gradient[((curr_y - 1) * max_rounded_px_w + curr_x) as usize] +=
-                alpha * ((g_yy + g_xy_sym) / g2_norm);
+            aux.obj_gradient[((curr_y - 1) * max_rounded_px_w + curr_x) as usize] = alpha.mul_add(
+                (g_yy + g_xy_sym) / g2_norm,
+                aux.obj_gradient[((curr_y - 1) * max_rounded_px_w + curr_x) as usize],
+            );
         }
 
         if curr_y < max_rounded_px_h - 1 {
-            aux.obj_gradient[((curr_y + 1) * max_rounded_px_w + curr_x) as usize] +=
-                alpha * ((g_yy + g_xy_sym) / g2_norm);
+            aux.obj_gradient[((curr_y + 1) * max_rounded_px_w + curr_x) as usize] = alpha.mul_add(
+                (g_yy + g_xy_sym) / g2_norm,
+                aux.obj_gradient[((curr_y + 1) * max_rounded_px_w + curr_x) as usize],
+            );
         }
 
         if curr_x < max_rounded_px_w - 1 && curr_y > 0 {
-            aux.obj_gradient[((curr_y - 1) * max_rounded_px_w + (curr_x + 1)) as usize] +=
-                alpha * ((-g_xy_sym) / g2_norm);
+            aux.obj_gradient[((curr_y - 1) * max_rounded_px_w + (curr_x + 1)) as usize] = alpha
+                .mul_add(
+                    (-g_xy_sym) / g2_norm,
+                    aux.obj_gradient[((curr_y - 1) * max_rounded_px_w + (curr_x + 1)) as usize],
+                );
         }
 
         if curr_x > 0 && curr_y < max_rounded_px_h - 1 {
-            aux.obj_gradient[((curr_y + 1) * max_rounded_px_w + (curr_x - 1)) as usize] +=
-                alpha * ((-g_xy_sym) / g2_norm);
+            aux.obj_gradient[((curr_y + 1) * max_rounded_px_w + (curr_x - 1)) as usize] = alpha
+                .mul_add(
+                    (-g_xy_sym) / g2_norm,
+                    aux.obj_gradient[((curr_y + 1) * max_rounded_px_w + (curr_x - 1)) as usize],
+                );
         }
     }
 }

--- a/backend/artefact-core/pipeline_simd_8/coef.rs
+++ b/backend/artefact-core/pipeline_simd_8/coef.rs
@@ -38,14 +38,18 @@ impl From<Coefficient> for SIMD8Coef {
     fn from(c: Coefficient) -> Self {
         let dct_coefs = c
             .dct_coefs
-            .chunks_exact(8)
-            .map(f32x8::from_slc)
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|c| f32x8::from_slc(c))
             .collect::<Vec<f32x8>>();
 
         let quant_table: [f32x8; 8] = c
             .quant_table
-            .chunks_exact(8)
-            .map(f32x8::from_slc)
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|c| f32x8::from_slc(c))
             .collect::<Vec<f32x8>>()
             .try_into()
             .expect("Invalid quant_table length");

--- a/backend/artefact-core/pipeline_simd_8/compute_step_prob.rs
+++ b/backend/artefact-core/pipeline_simd_8/compute_step_prob.rs
@@ -50,30 +50,58 @@ pub fn compute_step_prob(
                     // Apply sampling factors (upsampling)
                     match (coef.vertical_samp_factor, coef.horizontal_samp_factor) {
                         (SampleFactor::One, SampleFactor::One) => {
-                            obj_gradient[(cy * max_rounded_px_w + cx) as usize] += alpha * cosbs[j];
+                            obj_gradient[(cy * max_rounded_px_w + cx) as usize] = alpha.mul_add(
+                                cosbs[j],
+                                obj_gradient[(cy * max_rounded_px_w + cx) as usize],
+                            );
                         }
                         (SampleFactor::One, SampleFactor::Two) => {
-                            obj_gradient[(cy * max_rounded_px_w + cx * 2) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient[(cy * max_rounded_px_w + cx * 2 + 1) as usize] +=
-                                alpha * cosbs[j];
+                            obj_gradient[(cy * max_rounded_px_w + cx * 2) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * max_rounded_px_w + cx * 2) as usize],
+                                );
+                            obj_gradient[(cy * max_rounded_px_w + cx * 2 + 1) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * max_rounded_px_w + cx * 2 + 1) as usize],
+                                );
                         }
                         (SampleFactor::Two, SampleFactor::One) => {
-                            obj_gradient[(cy * 2 * max_rounded_px_w + cx) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx) as usize] +=
-                                alpha * cosbs[j];
+                            obj_gradient[(cy * 2 * max_rounded_px_w + cx) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * 2 * max_rounded_px_w + cx) as usize],
+                                );
+                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx) as usize],
+                                );
                         }
                         (SampleFactor::Two, SampleFactor::Two) => {
-                            obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2 + 1) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx * 2) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient
-                                [((cy * 2 + 1) * max_rounded_px_w + cx * 2 + 1) as usize] +=
-                                alpha * cosbs[j];
+                            obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2) as usize],
+                                );
+                            obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2 + 1) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2 + 1) as usize],
+                                );
+                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx * 2) as usize] =
+                                alpha.mul_add(
+                                    cosbs[j],
+                                    obj_gradient
+                                        [((cy * 2 + 1) * max_rounded_px_w + cx * 2) as usize],
+                                );
+                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx * 2 + 1) as usize] =
+                                alpha.mul_add(
+                                    cosbs[j],
+                                    obj_gradient
+                                        [((cy * 2 + 1) * max_rounded_px_w + cx * 2 + 1) as usize],
+                                );
                         }
                     }
                 }

--- a/backend/artefact-core/pipeline_simd_adaptive/coef.rs
+++ b/backend/artefact-core/pipeline_simd_adaptive/coef.rs
@@ -38,8 +38,10 @@ impl From<Coefficient> for SIMDAdaptiveCoef {
     fn from(c: Coefficient) -> Self {
         let dct_coefs = c
             .dct_coefs
-            .chunks_exact(64)
-            .map(f32x64::from_slc)
+            .as_chunks::<64>()
+            .0
+            .iter()
+            .map(|c| f32x64::from_slc(c))
             .collect::<Vec<f32x64>>();
 
         let quant_table = f32x64::from_array(c.quant_table);

--- a/backend/artefact-core/pipeline_simd_adaptive/compute_step_prob.rs
+++ b/backend/artefact-core/pipeline_simd_adaptive/compute_step_prob.rs
@@ -46,30 +46,58 @@ pub fn compute_step_prob(
                     // Apply sampling factors (upsampling)
                     match (coef.vertical_samp_factor, coef.horizontal_samp_factor) {
                         (SampleFactor::One, SampleFactor::One) => {
-                            obj_gradient[(cy * max_rounded_px_w + cx) as usize] += alpha * cosbs[j];
+                            obj_gradient[(cy * max_rounded_px_w + cx) as usize] = alpha.mul_add(
+                                cosbs[j],
+                                obj_gradient[(cy * max_rounded_px_w + cx) as usize],
+                            );
                         }
                         (SampleFactor::One, SampleFactor::Two) => {
-                            obj_gradient[(cy * max_rounded_px_w + cx * 2) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient[(cy * max_rounded_px_w + cx * 2 + 1) as usize] +=
-                                alpha * cosbs[j];
+                            obj_gradient[(cy * max_rounded_px_w + cx * 2) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * max_rounded_px_w + cx * 2) as usize],
+                                );
+                            obj_gradient[(cy * max_rounded_px_w + cx * 2 + 1) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * max_rounded_px_w + cx * 2 + 1) as usize],
+                                );
                         }
                         (SampleFactor::Two, SampleFactor::One) => {
-                            obj_gradient[(cy * 2 * max_rounded_px_w + cx) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx) as usize] +=
-                                alpha * cosbs[j];
+                            obj_gradient[(cy * 2 * max_rounded_px_w + cx) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * 2 * max_rounded_px_w + cx) as usize],
+                                );
+                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx) as usize],
+                                );
                         }
                         (SampleFactor::Two, SampleFactor::Two) => {
-                            obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2 + 1) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx * 2) as usize] +=
-                                alpha * cosbs[j];
-                            obj_gradient
-                                [((cy * 2 + 1) * max_rounded_px_w + cx * 2 + 1) as usize] +=
-                                alpha * cosbs[j];
+                            obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2) as usize],
+                                );
+                            obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2 + 1) as usize] = alpha
+                                .mul_add(
+                                    cosbs[j],
+                                    obj_gradient[(cy * 2 * max_rounded_px_w + cx * 2 + 1) as usize],
+                                );
+                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx * 2) as usize] =
+                                alpha.mul_add(
+                                    cosbs[j],
+                                    obj_gradient
+                                        [((cy * 2 + 1) * max_rounded_px_w + cx * 2) as usize],
+                                );
+                            obj_gradient[((cy * 2 + 1) * max_rounded_px_w + cx * 2 + 1) as usize] =
+                                alpha.mul_add(
+                                    cosbs[j],
+                                    obj_gradient
+                                        [((cy * 2 + 1) * max_rounded_px_w + cx * 2 + 1) as usize],
+                                );
                         }
                     }
                 }

--- a/backend/artefact-core/utils/traits.rs
+++ b/backend/artefact-core/utils/traits.rs
@@ -26,11 +26,11 @@ pub trait WriteTo {
 
 impl WriteTo for wide::f32x8 {
     fn write_to(&self, target: &mut [f32]) {
-        target.copy_from_slice(self.as_array_ref());
+        target.copy_from_slice(self.as_array());
     }
 
     fn write_partial_to(&self, target: &mut [f32], range: RangeInclusive<usize>) {
-        target.copy_from_slice(&self.as_array_ref()[range]);
+        target.copy_from_slice(&self.as_array()[range]);
     }
 }
 
@@ -140,14 +140,14 @@ pub trait SafeDiv {
 
 impl SafeDiv for wide::f32x8 {
     fn safe_div(&self, divisor: Self) -> Self {
-        match divisor.as_array_ref() {
+        match divisor.as_array() {
             divisor if divisor.contains(&0.0) => Self::from(
                 divisor
                     .iter()
                     .enumerate()
                     .map(|(i, g_norm)| match g_norm {
                         0.0 => 0.0,
-                        _ => self.as_array_ref()[i] / g_norm,
+                        _ => self.as_array()[i] / g_norm,
                     })
                     .collect::<Vec<f32>>()
                     .as_slice(),

--- a/backend/zune-jpeg/src/components.rs
+++ b/backend/zune-jpeg/src/components.rs
@@ -125,7 +125,7 @@ impl Components {
 
         trace!(
             "Component ID:{:?} \tHS:{} VS:{} QT:{}",
-            id, horizontal_sample, vertical_sample, quantization_table_number
+            id, horizontal_samp, vertical_samp, quant_table_number
         );
 
         Ok(Components {

--- a/backend/zune-jpeg/src/errors.rs
+++ b/backend/zune-jpeg/src/errors.rs
@@ -74,7 +74,7 @@ impl Debug for DecodeErrors {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Format(a) => write!(f, "{a:?}"),
-            Self::FormatStatic(a) => write!(f, "{:?}", &a),
+            Self::FormatStatic(a) => write!(f, "{:?}", a),
 
             Self::HuffmanDecode(reason) => {
                 write!(f, "Error decoding huffman values: {reason}")

--- a/backend/zune-jpeg/src/huffman.rs
+++ b/backend/zune-jpeg/src/huffman.rs
@@ -176,12 +176,11 @@ impl HuffmanTable {
                 // l -> Current code length,
                 // p => Its index in self.code and self.values
                 // Generate left justified code followed by all possible bit sequences
-                let mut look_bits = (huff_code[p] as usize) << (HUFF_LOOKAHEAD - l);
-
-                for _ in 0..1 << (HUFF_LOOKAHEAD - l) {
+                for look_bits in ((huff_code[p] as usize) << (HUFF_LOOKAHEAD - l)..)
+                    .take(1 << (HUFF_LOOKAHEAD - l))
+                {
                     self.lookup[look_bits] =
                         (i32::from(l) << HUFF_LOOKAHEAD) | i32::from(self.values[p]);
-                    look_bits += 1;
                 }
 
                 p += 1;

--- a/backend/zune-jpeg/src/lib.rs
+++ b/backend/zune-jpeg/src/lib.rs
@@ -59,7 +59,7 @@
 //! use zune_jpeg::JpegDecoder;
 //!
 //! let mut decoder = JpegDecoder::new(ZCursor::new(&[]));
-//! decoder.decode_headers().unwrap();
+//! decoder.decode().unwrap();
 //! let image_info = decoder.info().unwrap();
 //! println!("{},{}",image_info.width,image_info.height)
 //! ```
@@ -101,7 +101,6 @@
 #![deny(clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
 #![cfg_attr(not(feature = "x86"), forbid(unsafe_code))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![macro_use]
 extern crate alloc;
 extern crate core;
 


### PR DESCRIPTION
- pipeline_scalar: suboptimal_flops mul_add for fdata, cosb, tv,
  tv2 (compute_step.rs:63, compute_step_prob.rs:26/53,
  compute_step_tv.rs:71,76,79,83, compute_step_tv2.rs:103-132)
- pipeline_simd_8/adaptive: chunks_exact(8/64) -> as_chunks::<N>().0
  (coef.rs) and suboptimal_flops mul_add for obj_gradient
  (compute_step_prob.rs:53-76, 9 sites each)
- zune-jpeg: redundant borrow in errors.rs:77, remove deprecated
  #![macro_use] in lib.rs:104, explicit_counter_loop in
  huffman.rs:181 -> for look_bits in range.take(...)
- benches: rand 0.10 Rng->RngExt (dct/boxing/casting/init_slice),
  approx_constant FRAC_1_SQRT_2, clone_on_copy, needless_range_loop,
  uninit_vec allow for casting bench
- doc: fix decode_headers -> decode in lib.rs doctest
- Cargo.toml wide 0.7.33->1.6.1 and traits as_array
- verified: just check 0/0, cargo clippy 0 warnings, cargo test
  5/5 doctests

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>